### PR TITLE
LIS3DHH: Fix getX method

### DIFF
--- a/lis3dhh.py
+++ b/lis3dhh.py
@@ -140,7 +140,7 @@ class LIS3DHH():
         return res
 
     def getX(self):
-        return float(self.getYRaw()) * self.factor
+        return float(self.getXRaw()) * self.factor
 
     def getYList(self):
         return([self.read(REG_Y_L), self.read(REG_Y_H)])


### PR DESCRIPTION
The currently implementation of getX method takes datas from Y axis rather than from X axis.